### PR TITLE
added type of $fields and type of &$parentObject

### DIFF
--- a/Classes/Hook/CanonicalParametersGetDataHook.php
+++ b/Classes/Hook/CanonicalParametersGetDataHook.php
@@ -18,7 +18,7 @@ class CanonicalParametersGetDataHook implements ContentObjectGetDataHookInterfac
      *
      * @return string Get data result
      */
-    public function getDataExtension($getDataString, $fields, $sectionValue, $returnValue, &$parentObject)
+    public function getDataExtension($getDataString, array $fields, $sectionValue, $returnValue, \TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer &$parentObject)
     {
         if ($getDataString !== 'canonical_parameters') {
             return $returnValue;


### PR DESCRIPTION
Hello Nemo

Thank you for your extension, it's great, I like it.

First I tested your extension in my development environment, everthing was fine.
Then I installed your extension in my productive environment.
When I called my website I received only a white screen, nothing else (no error message).

My IDE told me there is something wrong in class CanonicalParametersGetDataHook.

In parameter of function getDataExtension I added type of $fields and type of &$parentObject and everthing is fine now.

My productive environment:
Typo3: 8.7.17
PHP: 7.1.23

Cheers